### PR TITLE
Adjust _calculate_linkage_scipy

### DIFF
--- a/seaborn/matrix.py
+++ b/seaborn/matrix.py
@@ -625,8 +625,12 @@ class _DendrogramPlotter(object):
         self.independent_coord = self.dendrogram['icoord']
 
     def _calculate_linkage_scipy(self):
-        linkage = hierarchy.linkage(self.array, method=self.method,
-                                    metric=self.metric)
+        from scipy.spatial.distance import pdist
+        dist = pdist(self.array, metric=self.metric)
+        
+        exec(f'from scipy.cluster.hierarchy import {method}')
+        exec(f'linkage = {method}(dist)')
+        #linkage = hierarchy.linkage(self.array, method=self.method, metric=self.metric)
         return linkage
 
     def _calculate_linkage_fastcluster(self):


### PR DESCRIPTION
Instead of directly using hierarchical.linkage, use the spacial.pdist function for distance matrix and then import the designated clustering method, e.g. ward, for clustering.
By splitting this to a two step procedure, it opens up more combination of distance metric and clustering method.
The linkage function limits euclidean metric for ward clustering, which bothers me, and hopefully this change would bypass it.